### PR TITLE
Fix https://github.com/jenspfahl/KeepAwake/issues/12 by adding mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This extension can be helpful when you give a presentation or are watching a vid
 	mkdir git
 	cd git
 	git clone https://github.com/jenspfahl/KeepAwake.git
+	mkdir -p ~/.local/share/gnome-shell/extensions
 	cp -r KeepAwake/KeepAwake@jepfa.de ~/.local/share/gnome-shell/extensions/
 	```
 	You can do `ln -s` instead of `cp -r` if you prefer.


### PR DESCRIPTION
Add a mkdir -p command to the installation instructions to create the extensions directory in case it is not there. (Which would result in cp copying the files directly into extensions directory as described in #12 .)
According to this [StackOverflow question](https://stackoverflow.com/questions/947954/how-to-have-the-cp-command-create-any-necessary-folders-for-copying-a-file-to-a) there is no better way to do this than mkdir -p (-p meaning "no error if existing, make parent directories as needed").