### PR TITLE
added Support for gtk4 (gnome 40 and 41)

### DIFF
--- a/KeepAwake@jepfa.de/metadata.json
+++ b/KeepAwake@jepfa.de/metadata.json
@@ -21,9 +21,11 @@
     "3.32",
     "3.34",
     "3.36",
-    "3.38"
+    "3.38",
+    "40",
+    "41"
   ], 
   "url": "https://github.com/jenspfahl/KeepAwake", 
   "uuid": "KeepAwake@jepfa.de", 
-  "version": 5
+  "version": 6
 }

--- a/KeepAwake@jepfa.de/prefs.js
+++ b/KeepAwake@jepfa.de/prefs.js
@@ -7,6 +7,9 @@ const Lang = imports.lang;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
+const Config = imports.misc.config;
+const [major] = Config.PACKAGE_VERSION.split('.');
+const shellVersion = Number.parseInt(major);
 
 const Gettext = imports.gettext.domain('KeepAwake');
 const _ = Gettext.gettext;
@@ -69,8 +72,13 @@ ShowDesktopSettingsWidget.prototype = {
                                  'hscrollbar-policy': Gtk.PolicyType.AUTOMATIC,
                                  'vscrollbar-policy': Gtk.PolicyType.AUTOMATIC,
                                  'hexpand': true, 'vexpand': true});
-        scollingWindow.set_child(this._grid);
-        scollingWindow.show();
+        if (shellVersion >= 40){
+            scollingWindow.set_child(this._grid);
+            scollingWindow.show();
+        }else {
+            scollingWindow.add_with_viewport(this._grid);
+            scollingWindow.show_all();
+        }
         return scollingWindow;
     }
 };

--- a/KeepAwake@jepfa.de/prefs.js
+++ b/KeepAwake@jepfa.de/prefs.js
@@ -27,7 +27,10 @@ ShowDesktopSettingsWidget.prototype = {
 
     _init: function() {
         this._grid = new Gtk.Grid();
-        this._grid.margin = 50;
+        this._grid.margin_start = 50;
+        this._grid.margin_end = 50;
+        this._grid.margin_top = 50;
+        this._grid.margin_bottom = 50;
         this._grid.row_spacing = this._grid.column_spacing = 20;
 	    this._settings = Convenience.getSettings();
 
@@ -66,8 +69,8 @@ ShowDesktopSettingsWidget.prototype = {
                                  'hscrollbar-policy': Gtk.PolicyType.AUTOMATIC,
                                  'vscrollbar-policy': Gtk.PolicyType.AUTOMATIC,
                                  'hexpand': true, 'vexpand': true});
-        scollingWindow.add_with_viewport(this._grid);
-        scollingWindow.show_all();
+        scollingWindow.set_child(this._grid);
+        scollingWindow.show();
         return scollingWindow;
     }
 };


### PR DESCRIPTION
Hi,
I found this extension and wanted it to work on my arch (btw 😉) system (Gnome 41). So I tried a bit around to get it to run under gtk4. In the end it were only two functions of the `ScrolledWindow` (that were deprecated/changed in gtk4) and the margins in the settings that needed to be adjusted.

Best regards and thank you for this handy extension