### PR TITLE
Fixes lost reference to mode "tween" text

### DIFF
--- a/KeepAwake@jepfa.de/extension.js
+++ b/KeepAwake@jepfa.de/extension.js
@@ -68,7 +68,7 @@ const BACKGROUND_COLOR = 'background-color';
 let _powerSettings, _sessionSettings, _screensaverSettings, _extensionSettings;
 
 // IU components
-let _trayButton, _bgTrayColor, _trayIconOn, _trayIconOff, _trayIconOnLock, _tweenText, _buttonPressEventId;
+let _trayButton, _bgTrayColor, _trayIconOn, _trayIconOff, _trayIconOnLock, _buttonPressEventId;
 
 // 0 = video mode off --> system/monitor (possibly) suspends when idle
 // 1 = video mode on --> system/monitor doesn't suspend when idle
@@ -230,7 +230,7 @@ function updateMode() {
 
 
 function showModeTween() {
-
+    let _tweenText;
 
     if (_mode == MODE_ON) {
         _tweenText = new St.Label({ style_class: 'video-label-on', text: _("Computer keeps awake.") });
@@ -254,13 +254,7 @@ function showModeTween() {
                      { opacity: 0,
                        time: 4,
                        transition: 'easeOutQuad',
-                       onComplete: hideModeTween });
-}
-
-
-function hideModeTween() {
-    Main.uiGroup.remove_actor(_tweenText);
-    _tweenText = null;
+                       onComplete: () => { Main.uiGroup.remove_actor(_tweenText); } });
 }
 
 


### PR DESCRIPTION
~~I'm still testing this on Fedora 35 / Gnome 41.6. So this is up as draft for discussion.~~

Tested on Fedora 35 / Gnome 41.6. Seem to work fine.

---

When mode is changed multiple times in quick succession, the following shows
up in logs:

    Jun 28 08:37:36 t14 gnome-shell[137049]: JS ERROR: Error calling onComplete: Error: Argument actor may not be null
                                             hideModeTween@/home/tadas/.local/share/gnome-shell/extensions/KeepAwake@jepfa.de/extension.js:262:18
                                             _callOnFunction@resource:///org/gnome/gjs/modules/script/tweener/tweener.js:190:16
                                             _updateTweenByIndex@resource:///org/gnome/gjs/modules/script/tweener/tweener.js:320:24
                                             _updateTweens@resource:///org/gnome/gjs/modules/script/tweener/tweener.js:333:18
                                             _onEnterFrame@resource:///org/gnome/gjs/modules/script/tweener/tweener.js:348:10
                                             _emit@resource:///org/gnome/gjs/modules/core/_signals.js:114:47
                                             start/this._timeoutID<@resource:///org/gnome/gjs/modules/script/tweener/tweener.js:75:20

Multiple calls to showModeTween sets _tweenText to the latest instance.
Meanwhile there's still previous active instances "fading out" and waiting
to be removed by hideModeTween. Then the first hideModeTween sets the _tweenText
to null. Subsequent callbacks of other instances then attempt to call
Main.uiGroup.remove_actor with null.

Fix - make the variable local to the showModeTween and make use of js closures.