### PR TITLE
Avoid icon object double destruction

### DIFF
--- a/KeepAwake@jepfa.de/extension.js
+++ b/KeepAwake@jepfa.de/extension.js
@@ -456,6 +456,7 @@ function disable() {
     _extensionSettings.set_int(SESSION_DELAY_KEY, SESSION_DELAY_DEFAULT);
     _extensionSettings.set_boolean(SCREENSAVER_ACTIVATION_KEY, SCREENSAVER_ACTIVATION_DEFAULT);
 
+    _trayButton.set_child(null);
     _trayButton.destroy();
     _trayButton = null;
     _trayIconOn.destroy();


### PR DESCRIPTION
Harmless issue - it only causes some logs noise.

At the time `disable()` function is called _trayButton has a reference to one of 3 icons. When `destroy()` is called on that button - it destroys child as well.

When further down the line we destroy all 3 icon objects, one icon is already destroyed. And it throws this exception:

    Object St.Icon (0x55b7873714b0), has been already disposed — impossible to access it. This might
    be caused by the object having been destroyed from C code using something such as destroy(),
    dispose(), or remove() vfuncs.
    == Stack trace for context 0x55b785d01320 ==
    #0   55b7893f55c0 i   /home/tadas/.local/share/gnome-shell/extensions/KeepAwake@jepfa.de/extension.js:463 (16ba4e942790 @ 369)
    #1   7ffed8b78e40 b   resource:///org/gnome/shell/ui/extensionSystem.js:125 (34a9db816330 @ 386)
    #2   55b7893f5468 i   resource:///org/gnome/shell/ui/extensionSystem.js:536 (34a9db816bf0 @ 15)
    #3   7ffed8b798d0 b   self-hosted:164 (23eb1cd490b0 @ 272)
    #4   55b7893f53e0 i   resource:///org/gnome/shell/ui/extensionSystem.js:536 (34a9db816ab0 @ 116)
    #5   55b7893f5358 i   resource:///org/gnome/shell/ui/extensionSystem.js:658 (34a9db81a0b0 @ 17)
    #6   7ffed8b7a310 b   self-hosted:1121 (23eb1cd7eec0 @ 432)
    #7   7ffed8b7a410 b   resource:///org/gnome/gjs/modules/core/_signals.js:114 (23eb1cda0740 @ 433)
    #8   7ffed8b7ab90 b   resource:///org/gnome/shell/ui/sessionMode.js:204 (1c7ff8f6ed80 @ 283)
    #9   55b7893f5200 i   resource:///org/gnome/shell/ui/sessionMode.js:163 (1c7ff8f6ec40 @ 66)
    #10   55b7893f5150 i   resource:///org/gnome/shell/ui/screenShield.js:620 (1c7ff8f65600 @ 206)
    #11   55b7893f5090 i   resource:///org/gnome/shell/ui/screenShield.js:666 (1c7ff8f65650 @ 342)
    #12   55b7893f5008 i   resource:///org/gnome/shell/ui/screenShield.js:294 (1c7ff8f62ce0 @ 25)

This removes responsibility of destroying child from instance of the button by setting child reference to null before calling destroy.