### PR TITLE
Add touch support (#16)

### DIFF
--- a/KeepAwake@jepfa.de/extension.js
+++ b/KeepAwake@jepfa.de/extension.js
@@ -5,7 +5,6 @@ const Main = imports.ui.main;
 const Tweener = imports.tweener.tweener;
 const Gio = imports.gi.Gio;
 const Clutter = imports.gi.Clutter;
-const Mainloop = imports.mainloop;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -297,22 +296,19 @@ function color_from_string(color) {
 }
 
 
-function _handleIconClicked() {
+function _handleIconClicked(actor, event) {
 
-    // prevent multiple touch event in short succession
-    if (!this._touchTooSoon) {
-        this._touchTooSoon = true;
+    // only trigger clicked event on cursor click (mouse/touchpad) or touch begin
+    // to prevent multiple triggers on a single touch event (touch start + touch end)
+    if (event.type() === Clutter.EventType.BUTTON_PRESS ||
+        event.type() === Clutter.EventType.TOUCH_BEGIN) {
 
         toggleMode();
         updateIcon();
         if (getEnableNotifications()) {
             showModeTween();
         }
-
-        // reset the flag after a small delay to allow touch events again
-        Mainloop.timeout_add(200, () => { this._touchTooSoon = false });
     }
-
 }
 
 

--- a/KeepAwake@jepfa.de/extension.js
+++ b/KeepAwake@jepfa.de/extension.js
@@ -5,6 +5,7 @@ const Main = imports.ui.main;
 const Tweener = imports.tweener.tweener;
 const Gio = imports.gi.Gio;
 const Clutter = imports.gi.Clutter;
+const Mainloop = imports.mainloop;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -298,10 +299,18 @@ function color_from_string(color) {
 
 function _handleIconClicked() {
 
-    toggleMode();
-    updateIcon();
-    if (getEnableNotifications()) {
-        showModeTween();
+    // prevent multiple touch event in short succession
+    if (!this._touchTooSoon) {
+        this._touchTooSoon = true;
+
+        toggleMode();
+        updateIcon();
+        if (getEnableNotifications()) {
+            showModeTween();
+        }
+
+        // reset the flag after a small delay to allow touch events again
+        Mainloop.timeout_add(200, () => { this._touchTooSoon = false });
     }
 
 }
@@ -421,6 +430,7 @@ function enable() {
     Main.panel._rightBox.insert_child_at_index(_trayButton, 0);
 
     _buttonPressEventId = _trayButton.connect('button-press-event', _handleIconClicked);
+    _buttonPressEventId = _trayButton.connect('touch-event', _handleIconClicked);
 
 
     // restore previous state

--- a/KeepAwake@jepfa.de/metadata.json
+++ b/KeepAwake@jepfa.de/metadata.json
@@ -15,5 +15,5 @@
   ],
   "url": "https://github.com/jenspfahl/KeepAwake",
   "uuid": "KeepAwake@jepfa.de",
-  "version": 9
+  "version": 12
 }


### PR DESCRIPTION
Trigger click at `touch-event` signal to support touch displays.

~The signal is triggered every **start** or **end** of a touch event, so it is needed a small workaround (disable timeout) to not call the click function two times every time the user presses the icon.~

Update commit `30275df`: no need for timeout (ugly workaround), not the functions is triggered only by `touch-begin` events and **not** `touch-end`