### PR TITLE
Update metadata.json

### DIFF
--- a/KeepAwake@jepfa.de/metadata.json
+++ b/KeepAwake@jepfa.de/metadata.json
@@ -4,7 +4,7 @@
   "settings-schema": "org.gnome.shell.extensions.KeepAwake@jepfa.de",
   "gettext-domain" : "KeepAwake",
   "shell-version": [
-    "45","46","47"
+    "45","46","47","48"
   ],
   "url": "https://github.com/jenspfahl/KeepAwake",
   "uuid": "KeepAwake@jepfa.de",


### PR DESCRIPTION
Added Gnome  Shell version 48 since the beta is out now. See: https://gjs.guide/extensions/upgrading/gnome-shell-48.html